### PR TITLE
Add getPixel and putPixel changes

### DIFF
--- a/texture.cpp
+++ b/texture.cpp
@@ -16,12 +16,68 @@ void getMasks(Uint32 *gmask, Uint32 *rmask, Uint32 *bmask, Uint32 *amask)
 #endif
 }
 
+Uint32 getPixel(SDL_Surface *surface, int x, int y)
+{
+    int bpp = surface->format->BytesPerPixel;
+    /* Here p is the address to the pixel we want to retrieve */
+    Uint8 *p = (Uint8 *)surface->pixels + y * surface->pitch + x * bpp;
+
+    switch(bpp) {
+    case 1:
+        return *p;
+        break;
+
+    case 2:
+        return *(Uint16 *)p;
+        break;
+
+    case 3:
+        if(SDL_BYTEORDER == SDL_BIG_ENDIAN)
+            return p[0] << 16 | p[1] << 8 | p[2];
+        else
+            return p[0] | p[1] << 8 | p[2] << 16;
+        break;
+
+    case 4:
+        return *(Uint32 *)p;
+        break;
+
+    default:
+        return 0;       /* shouldn't happen, but avoids warnings */
+    }
+}
+
 void putPixel(SDL_Surface *surface, int x, int y, Uint32 pixel)
 {
-	// Convert the pixels to 32 bit
-	Uint32 *pixels = static_cast<Uint32 *>(surface->pixels);
-	// Set the pixel
-	pixels[( y * surface->w ) + x] = pixel;
+    int bpp = surface->format->BytesPerPixel;
+    /* Here p is the address to the pixel we want to set */
+    Uint8 *p = (Uint8 *)surface->pixels + y * surface->pitch + x * bpp;
+
+    switch(bpp) {
+    case 1:
+        *p = pixel;
+        break;
+
+    case 2:
+        *(Uint16 *)p = pixel;
+        break;
+
+    case 3:
+        if(SDL_BYTEORDER == SDL_BIG_ENDIAN) {
+            p[0] = (pixel >> 16) & 0xff;
+            p[1] = (pixel >> 8) & 0xff;
+            p[2] = pixel & 0xff;
+        } else {
+            p[0] = pixel & 0xff;
+            p[1] = (pixel >> 8) & 0xff;
+            p[2] = (pixel >> 16) & 0xff;
+        }
+        break;
+
+    case 4:
+        *(Uint32 *)p = pixel;
+        break;
+    }
 }
 
 SDL_Surface *errorSurface(int w, int h)

--- a/texture.hpp
+++ b/texture.hpp
@@ -6,5 +6,6 @@
 
 void getMasks(Uint32 *gmask, Uint32 *rmask, Uint32 *bmask, Uint32 *amask);
 void putPixel(SDL_Surface *surface, int x, int y, Uint32 pixel);
+Uint32 getPixel(SDL_Surface *surface, int x, int y);
 SDL_Surface *errorSurface(int w = 32, int h = 32);
 SDL_Texture *loadTextureFromFile(SDL_Renderer *renderer, const std::string &imagePath);


### PR DESCRIPTION
This was needed for silhouetting the pokemon for the quiz.
```cpp
// Pokemon image
    {
        SDL_Surface *surface = IMG_Load(m_pokeData.getSpriteLocation().c_str());
        if (!surface) {
            std::cerr << "IMG_Load Error: " << IMG_GetError() << std::endl;
            exit(1);
        }
        SDL_LockSurface(surface);
        Uint32 pixel = SDL_MapRGBA(surface->format, 0, 0, 0, 255);
        for (int y = 0; y < surface->h; ++y) {
            for (int x = 0; x < surface->w; ++x) {
                Uint8 r, g, b, a;
                SDL_GetRGBA(getPixel(surface, x, y), surface->format, &r, &g, &b, &a);
                if (a != 0) {
                    putPixel(surface, x, y, pixel);
                }
            }
        }
        SDL_UnlockSurface(surface);

        SDL_Texture *texture = SDL_CreateTextureFromSurface(m_context->renderer, surface);
        SDL_FreeSurface(surface);

        m_pokemonImage.setImage(texture);
        m_pokemonImage.setPosition(0, 0);
    }
```